### PR TITLE
Add custom params text field to software encoders

### DIFF
--- a/encoder_info.h
+++ b/encoder_info.h
@@ -25,6 +25,7 @@ struct EncoderInfo {
     uint8_t qp[3]{};
     std::map<int, std::string> presets{};
     int defaultPreset{};
+    const char* customParamsKey{};
 };
 
 }

--- a/ffmpeg_encoder.cpp
+++ b/ffmpeg_encoder.cpp
@@ -229,6 +229,10 @@ void FFmpegEncoder::ApplyOptions(AVCodecContext* ctx, UISettingsController& sett
             av_opt_set(ctx->priv_data, "preset", preset->second.c_str(), 0);
         }
     }
+
+    if (encoderInfo.customParamsKey != nullptr && !settings.GetCustomParams().empty()) {
+        av_opt_set(ctx->priv_data, encoderInfo.customParamsKey, settings.GetCustomParams().c_str(), 0);
+    }
 }
 
 StatusCode FFmpegEncoder::DoProcess(HostBufferRef* p_pBuff) {

--- a/svt_av1_encoder.cpp
+++ b/svt_av1_encoder.cpp
@@ -30,6 +30,7 @@ const EncoderInfo SvtAv1Encoder::encoderInfo = {
             {12, "12"},
         },
     .defaultPreset = 8,
+    .customParamsKey = "svtav1-params",
 };
 
 SvtAv1Encoder::SvtAv1Encoder() { FFmpegEncoder::encoderInfo = encoderInfo; }

--- a/uisettings_controller.cpp
+++ b/uisettings_controller.cpp
@@ -25,6 +25,11 @@ void UISettingsController::Load(IPropertyProvider* values) {
     values->GetINT32(qpId.c_str(), qp);
     values->GetINT32(bitrateId.c_str(), bitRate);
     values->GetINT32(presetId.c_str(), preset);
+
+    std::string customParamsStr;
+    if (values->GetString(customParamsId.c_str(), customParamsStr)) {
+        customParams = customParamsStr;
+    }
 }
 
 StatusCode UISettingsController::Render(HostListRef* settingsList) const {
@@ -59,6 +64,7 @@ void UISettingsController::InitDefaults() {
     qpId = prefix + "qp";
     bitrateId = prefix + "bitrate";
     presetId = prefix + "preset";
+    customParamsId = prefix + "custom_params";
 }
 
 void UISettingsController::SetFirstSupportedQualityMode() {
@@ -87,6 +93,15 @@ StatusCode UISettingsController::RenderQuality(HostListRef* settingsList) const 
         item.MakeComboBox("Encoder Preset", textsVec, valuesVec, preset);
         if (!item.IsSuccess() || !settingsList->Append(&item)) {
             g_Log(logLevelError, "FFmpeg Plugin :: Failed to populate encoder preset UI entry");
+            return errFail;
+        }
+    }
+
+    if (encoderInfo.customParamsKey != nullptr) {
+        HostUIConfigEntryRef item(customParamsId);
+        item.MakeTextBox("Encoder Params", customParams, "");
+        if (!item.IsSuccess() || !settingsList->Append(&item)) {
+            g_Log(logLevelError, "FFmpeg Plugin :: Failed to populate custom params UI entry");
             return errFail;
         }
     }
@@ -163,3 +178,5 @@ int32_t UISettingsController::GetQP() const { return std::max<int>(0, qp); }
 int32_t UISettingsController::GetBitRate() const { return bitRate * 1000; }
 
 int32_t UISettingsController::GetPreset() const { return preset; }
+
+const std::string& UISettingsController::GetCustomParams() const { return customParams; }

--- a/uisettings_controller.h
+++ b/uisettings_controller.h
@@ -28,6 +28,7 @@ class UISettingsController final {
     int32_t GetQP() const;
     int32_t GetBitRate() const;
     int32_t GetPreset() const;
+    const std::string& GetCustomParams() const;
 
    private:
     HostCodecConfigCommon commonProps;
@@ -37,11 +38,13 @@ class UISettingsController final {
     int32_t qp{};
     int32_t bitRate{};
     int32_t preset{};
+    std::string customParams;
 
     std::string qualityModeId;
     std::string qpId;
     std::string bitrateId;
     std::string presetId;
+    std::string customParamsId;
 };
 
 }

--- a/x264_encoder.cpp
+++ b/x264_encoder.cpp
@@ -26,6 +26,7 @@ const EncoderInfo X264Encoder::encoderInfo = {
             {8, "veryslow"},
         },
     .defaultPreset = 5,
+    .customParamsKey = "x264-params",
 };
 
 X264Encoder::X264Encoder() { FFmpegEncoder::encoderInfo = encoderInfo; }

--- a/x265_encoder.cpp
+++ b/x265_encoder.cpp
@@ -26,6 +26,7 @@ const EncoderInfo X265Encoder::encoderInfo = {
             {8, "veryslow"},
         },
     .defaultPreset = 5,
+    .customParamsKey = "x265-params",
 };
 
 X265Encoder::X265Encoder() { FFmpegEncoder::encoderInfo = encoderInfo; }


### PR DESCRIPTION
It allows to specify some specific encoding parameters. 
An example is being able to disable open gop on x265 for Youtube export